### PR TITLE
config: add Microsoft ML-For-Beginners to Computer Science Courses

### DIFF
--- a/configs/collections/10049.computer-science-courses.yml
+++ b/configs/collections/10049.computer-science-courses.yml
@@ -1,4 +1,4 @@
-id: 10049
+id: 10050
 name: Computer Science Courses
 items:
   - rcore-os/rCore
@@ -26,3 +26,4 @@ items:
   - yandexdataschool/nlp_course
   - microsoft/c9-python-getting-started
   - mit-pdos/xv6-public
+  - microsoft/ML-For-Beginners


### PR DESCRIPTION
Added microsoft/ML-For-Beginners repository to the list and updated collection ID from 10049 to 10050.
